### PR TITLE
Add logging to adeleg to facilitate troubleshooting/debugging

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -96,7 +96,18 @@ namespace adeleg
                 else
                     break;
             }
-            Log.Initialize(verbose || args.Length == 0, logFilePath);
+#if !DEBUG
+            try
+            {
+#endif
+                Log.Initialize(verbose || args.Length == 0, logFilePath);
+#if !DEBUG
+            }
+            catch (Exception exc)
+            {
+                return FailWithError(exc.Message);
+            }
+#endif
 
             List<Result> templates = LoadTemplates();
 
@@ -127,21 +138,19 @@ namespace adeleg
             List<Result> results = new List<Result>();
             bool generalize = false;
 
-            bool verbose = false;
-            string logFilePath = null;
+            // Log.Initialize() already called in Main(); just compute startIndex
             int startIndex = 0;
             for (int k = 0; k < args.Length; k++)
             {
                 if (args[k] == "--verbose" || args[k] == "-v")
                 {
-                    verbose = true;
                     startIndex = k + 1;
                 }
                 else if (args[k] == "--log-file")
                 {
                     if (k + 1 >= args.Length)
                         return FailWithError("file path required after --log-file");
-                    logFilePath = args[++k];
+                    ++k;
                     startIndex = k + 1;
                 }
                 else
@@ -149,7 +158,6 @@ namespace adeleg
                     break;
                 }
             }
-            // Log.Initialize() already called in Main()
 
             if (startIndex >= args.Length)
             {
@@ -323,6 +331,7 @@ namespace adeleg
             var res = connectform.ShowDialog();
             if (res != DialogResult.OK)
             {
+                Log.Close();
                 Environment.Exit(1);
             }
 

--- a/Main.cs
+++ b/Main.cs
@@ -55,7 +55,7 @@ namespace adeleg
 
         static List<Result> LoadTemplates(string dirPath)
         {
-            Log.Info($"Loading templates from {dirPath}");
+            Console.WriteLine($" [.] Loading templates from {dirPath}");
             DirectoryInfo dir = new DirectoryInfo(dirPath);
             List<Result> templates = new List<Result>();
             if (dir.Exists)
@@ -318,7 +318,7 @@ namespace adeleg
             if (connectform.dataSources.Count > 0)
             {
                 // TODO: multithreading here, with reporting in a GUI status bar
-                Log.Info($"Computing from {connectform.dataSources.Count} data sources...");
+                Console.WriteLine($" [.] Computing from {connectform.dataSources.Count} data sources...");
                 foreach (string partitionDN in engine.ListPartitionDNs())
                 {
                     results.AddRange(engine.Scan(partitionDN, true));
@@ -326,7 +326,7 @@ namespace adeleg
             }
             else
             {
-                Log.Info("Showing cached results only");
+                Console.WriteLine(" [.] Showing cached results only");
             }
 
             Application.Run(new TreeWindow(results, new HashSet<string>(engine.ListPartitionDNs())));

--- a/Main.cs
+++ b/Main.cs
@@ -55,7 +55,7 @@ namespace adeleg
 
         static List<Result> LoadTemplates(string dirPath)
         {
-            Console.WriteLine($" [.] Loading templates from {dirPath}");
+            Log.Info($"Loading templates from {dirPath}");
             DirectoryInfo dir = new DirectoryInfo(dirPath);
             List<Result> templates = new List<Result>();
             if (dir.Exists)
@@ -84,6 +84,20 @@ namespace adeleg
         [STAThread]
         static int Main(string[] args)
         {
+            // Pre-parse logging flags so Log is available as early as possible
+            bool verbose = false;
+            string logFilePath = null;
+            for (int k = 0; k < args.Length; k++)
+            {
+                if (args[k] == "--verbose" || args[k] == "-v")
+                    verbose = true;
+                else if (args[k] == "--log-file" && k + 1 < args.Length)
+                    logFilePath = args[++k];
+                else
+                    break;
+            }
+            Log.Initialize(verbose || args.Length == 0, logFilePath);
+
             List<Result> templates = LoadTemplates();
 
             if (args.Length > 0)
@@ -135,7 +149,7 @@ namespace adeleg
                     break;
                 }
             }
-            Log.Initialize(verbose, logFilePath);
+            // Log.Initialize() already called in Main()
 
             if (startIndex >= args.Length)
             {
@@ -318,7 +332,7 @@ namespace adeleg
             if (connectform.dataSources.Count > 0)
             {
                 // TODO: multithreading here, with reporting in a GUI status bar
-                Console.WriteLine($" [.] Computing from {connectform.dataSources.Count} data sources...");
+                Log.Info($"Computing from {connectform.dataSources.Count} data sources...");
                 foreach (string partitionDN in engine.ListPartitionDNs())
                 {
                     results.AddRange(engine.Scan(partitionDN, true));
@@ -326,10 +340,11 @@ namespace adeleg
             }
             else
             {
-                Console.WriteLine(" [.] Showing cached results only");
+                Log.Info("Showing cached results only");
             }
 
             Application.Run(new TreeWindow(results, new HashSet<string>(engine.ListPartitionDNs())));
+            Log.Close();
             return 0;
         }
     }

--- a/Main.cs
+++ b/Main.cs
@@ -20,6 +20,10 @@ namespace adeleg
             Console.WriteLine("");
             Console.WriteLine("Usage: adeleg.exe (without options to start a GUI)");
             Console.WriteLine("");
+            Console.WriteLine("Global options:");
+            Console.WriteLine("       adeleg.exe [--verbose|-v] (to enable diagnostic logging to stderr)");
+            Console.WriteLine("                  [--log-file <path>] (to write diagnostic logs to a file)");
+            Console.WriteLine("");
             Console.WriteLine("       adeleg.exe ldap [--server|-s <server>] (to override the default DC locator)");
             Console.WriteLine("                       [--username|-u <username>] (to not use the default Windows SSO)");
             Console.WriteLine("                       [--domain|-d <domain>] (user's domain name, when using -u)");
@@ -109,7 +113,31 @@ namespace adeleg
             List<Result> results = new List<Result>();
             bool generalize = false;
 
-            for (int i = 0; i < args.Length; i++)
+            bool verbose = false;
+            string logFilePath = null;
+            int startIndex = 0;
+            for (int k = 0; k < args.Length; k++)
+            {
+                if (args[k] == "--verbose" || args[k] == "-v")
+                {
+                    verbose = true;
+                    startIndex = k + 1;
+                }
+                else if (args[k] == "--log-file")
+                {
+                    if (k + 1 >= args.Length)
+                        return FailWithError("file path required after --log-file");
+                    logFilePath = args[++k];
+                    startIndex = k + 1;
+                }
+                else
+                {
+                    break;
+                }
+            }
+            Log.Initialize(verbose, logFilePath);
+
+            for (int i = startIndex; i < args.Length; i++)
             {
                 if (args[i] == "--help" || args[i] == "-h" || args[i] == "-?")
                 {
@@ -250,6 +278,7 @@ namespace adeleg
                 Console.WriteLine(res.ToJson());
             }
 
+            Log.Close();
             return 0;
         }
 
@@ -260,6 +289,7 @@ namespace adeleg
             Console.Error.WriteLine("Error, cannot continue: {0}", err);
             Console.Error.WriteLine("===============");
             Console.Error.WriteLine("");
+            Log.Close();
             return 1;
         }
 

--- a/Main.cs
+++ b/Main.cs
@@ -97,10 +97,13 @@ namespace adeleg
                     break;
             }
 #if !DEBUG
+            // In release builds, catch Log.Initialize failures (e.g. invalid --log-file path)
+            // so they surface as friendly errors via FailWithError instead of unhandled exceptions.
+            // In debug builds, let exceptions propagate for full stack trace visibility.
             try
             {
 #endif
-                Log.Initialize(verbose || args.Length == 0, logFilePath);
+                Log.Initialize(verbose, logFilePath);
 #if !DEBUG
             }
             catch (Exception exc)

--- a/Main.cs
+++ b/Main.cs
@@ -171,6 +171,7 @@ namespace adeleg
                 if (args[i] == "--help" || args[i] == "-h" || args[i] == "-?")
                 {
                     ShowUsage();
+                    Log.Close();
                     return 1;
                 }
                 else if (args[i] == "--generalize")

--- a/Main.cs
+++ b/Main.cs
@@ -55,7 +55,7 @@ namespace adeleg
 
         static List<Result> LoadTemplates(string dirPath)
         {
-            Console.WriteLine($" [.] Loading templates from {dirPath}");
+            Log.Info($"Loading templates from {dirPath}");
             DirectoryInfo dir = new DirectoryInfo(dirPath);
             List<Result> templates = new List<Result>();
             if (dir.Exists)
@@ -318,7 +318,7 @@ namespace adeleg
             if (connectform.dataSources.Count > 0)
             {
                 // TODO: multithreading here, with reporting in a GUI status bar
-                Console.WriteLine($" [.] Computing from {connectform.dataSources.Count} data sources...");
+                Log.Info($"Computing from {connectform.dataSources.Count} data sources...");
                 foreach (string partitionDN in engine.ListPartitionDNs())
                 {
                     results.AddRange(engine.Scan(partitionDN, true));
@@ -326,7 +326,7 @@ namespace adeleg
             }
             else
             {
-                Console.WriteLine(" [.] Showing cached results only");
+                Log.Info("Showing cached results only");
             }
 
             Application.Run(new TreeWindow(results, new HashSet<string>(engine.ListPartitionDNs())));

--- a/Main.cs
+++ b/Main.cs
@@ -137,6 +137,13 @@ namespace adeleg
             }
             Log.Initialize(verbose, logFilePath);
 
+            if (startIndex >= args.Length)
+            {
+                ShowUsage();
+                Log.Close();
+                return 1;
+            }
+
             for (int i = startIndex; i < args.Length; i++)
             {
                 if (args[i] == "--help" || args[i] == "-h" || args[i] == "-?")

--- a/adeleg.csproj
+++ b/adeleg.csproj
@@ -80,6 +80,7 @@
     <Compile Include="engine\connector\LdapLiveConnector.cs" />
     <Compile Include="engine\connector\OradadConnector.cs" />
     <Compile Include="engine\Engine.cs" />
+    <Compile Include="engine\Logging.cs" />
     <Compile Include="engine\Result.cs" />
     <Compile Include="engine\ResultLocation.cs" />
     <Compile Include="engine\ResultTrustee.cs" />

--- a/engine/Engine.cs
+++ b/engine/Engine.cs
@@ -90,7 +90,7 @@ namespace adeleg.engine
                     Log.Info($"Registering partition '{partitionDN}' with forest root '{forestDN}'");
                 }
             }
-            foreach (string forestDN in forestRootPerNamingContext.Values.Distinct())
+            foreach (string forestDN in forestRootPerNamingContext.Values.Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 if (string.IsNullOrEmpty(forestDN))
                 {

--- a/engine/Engine.cs
+++ b/engine/Engine.cs
@@ -87,12 +87,18 @@ namespace adeleg.engine
                     // If two sources provide the same partition, only one is kept (random)
                     dataSourcePerNamingContext[partitionDN] = dataSource;
                     forestRootPerNamingContext[partitionDN] = forestDN;
+                    Log.Info($"Registering partition '{partitionDN}' with forest root '{forestDN}'");
                 }
             }
             foreach (string forestDN in forestRootPerNamingContext.Values)
             {
                 if (!dataSourcePerNamingContext.ContainsKey(forestDN))
                 {
+                    Log.Error($"Forest root DN '{forestDN}' is not among the registered partition DNs");
+                    Log.Error("Registered partition DNs:");
+                    foreach (string key in dataSourcePerNamingContext.Keys)
+                        Log.Error($"  - {key}");
+                    Log.Error("This typically occurs when connecting to a child domain DC in a multi-domain forest. The child DC's RootDSE reports the forest root as rootDomainNamingContext, but the forest root's naming context is not among the namingContexts hosted by this DC.");
                     throw new Exception($"Root domain {forestDN} needs to be included in data inputs to be scanned");
                 }
             }
@@ -125,7 +131,7 @@ namespace adeleg.engine
                     Tuple<ObjectClass, string, string> resolved = this.ResolveFromSid(forest.Key, sid);
                     if (resolved == null || (resolved.Item2 == null && resolved.Item3 == null))
                     {
-                        Console.WriteLine($" [!] Warning: unable to resolve {sid} in {forest.Key}");
+                        Log.Warn($"Unable to resolve {sid} in {forest.Key}");
                         continue;
                     }
 
@@ -136,7 +142,7 @@ namespace adeleg.engine
                             SecurityIdentifier memberSid = ResolveDnToSid(memberDN);
                             if (memberSid == null)
                             {
-                                Console.WriteLine($" [!] Warning: unable to resolve {memberDN} to a SID");
+                                Log.Warn($"Unable to resolve {memberDN} to a SID");
                                 continue;
                             }
 
@@ -149,7 +155,9 @@ namespace adeleg.engine
 
         private ForestMetadata ScanForestMetadata(string forestDN, IConnector rootDomainDataSource)
         {
+            Log.Info($"Scanning forest metadata for '{forestDN}'");
             SecurityIdentifier forestSid = rootDomainDataSource.GetDomainSidByPartitionDN(forestDN);
+            Log.Verbose($"Forest SID for '{forestDN}' = {forestSid}");
 
             ForestMetadata res = new ForestMetadata
             {

--- a/engine/Engine.cs
+++ b/engine/Engine.cs
@@ -90,7 +90,7 @@ namespace adeleg.engine
                     Log.Info($"Registering partition '{partitionDN}' with forest root '{forestDN}'");
                 }
             }
-            foreach (string forestDN in forestRootPerNamingContext.Values)
+            foreach (string forestDN in forestRootPerNamingContext.Values.Distinct())
             {
                 if (string.IsNullOrEmpty(forestDN))
                 {

--- a/engine/Engine.cs
+++ b/engine/Engine.cs
@@ -71,9 +71,9 @@ namespace adeleg.engine
             "{domainSid}-521", // Read-Only Domain Controllers
         };
         private List<Result> templates;
-        private Dictionary<string, IConnector> dataSourcePerNamingContext = new Dictionary<string, IConnector>();
-        private Dictionary<string, string> forestRootPerNamingContext = new Dictionary<string, string>();
-        private Dictionary<string, ForestMetadata> metadataPerForest = new Dictionary<string, ForestMetadata>();
+        private Dictionary<string, IConnector> dataSourcePerNamingContext = new Dictionary<string, IConnector>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, string> forestRootPerNamingContext = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, ForestMetadata> metadataPerForest = new Dictionary<string, ForestMetadata>(StringComparer.OrdinalIgnoreCase);
 
         public Engine(IEnumerable<IConnector> dataSources, List<Result> templates)
         {

--- a/engine/Engine.cs
+++ b/engine/Engine.cs
@@ -92,6 +92,11 @@ namespace adeleg.engine
             }
             foreach (string forestDN in forestRootPerNamingContext.Values)
             {
+                if (string.IsNullOrEmpty(forestDN))
+                {
+                    Log.Error("A data source returned a null or empty rootDomainNamingContext. This usually means the domain controller's RootDSE did not include the rootDomainNamingContext attribute.");
+                    throw new Exception("A data source returned a null or empty forest root DN (rootDomainNamingContext). Ensure the domain controller is reachable and returns valid RootDSE information.");
+                }
                 if (!dataSourcePerNamingContext.ContainsKey(forestDN))
                 {
                     Log.Error($"Forest root DN '{forestDN}' is not among the registered partition DNs");

--- a/engine/Engine.cs
+++ b/engine/Engine.cs
@@ -170,12 +170,12 @@ namespace adeleg.engine
                 schemaAdminSid = new SecurityIdentifier($"{forestSid}-518"),
                 schemaNC = rootDomainDataSource.GetSchemaNC(),
 
-                domainSidPerPartition = new Dictionary<string, SecurityIdentifier>(),
-                domainAdminsSidPerPartition = new Dictionary<string, SecurityIdentifier>(),
-                sidResolutionCachePerPartition = new Dictionary<string, Dictionary<SecurityIdentifier, Tuple<ObjectClass, string, string>>>(),
-                defaultSdPerPartitionPerClassName = new Dictionary<string, Dictionary<string, CommonSecurityDescriptor>>(),
-                adminSdHolderSdPerPartition = new Dictionary<string, CommonSecurityDescriptor>(),
-                adminSdHolderProtectedDn = new HashSet<string>(),
+                domainSidPerPartition = new Dictionary<string, SecurityIdentifier>(StringComparer.OrdinalIgnoreCase),
+                domainAdminsSidPerPartition = new Dictionary<string, SecurityIdentifier>(StringComparer.OrdinalIgnoreCase),
+                sidResolutionCachePerPartition = new Dictionary<string, Dictionary<SecurityIdentifier, Tuple<ObjectClass, string, string>>>(StringComparer.OrdinalIgnoreCase),
+                defaultSdPerPartitionPerClassName = new Dictionary<string, Dictionary<string, CommonSecurityDescriptor>>(StringComparer.OrdinalIgnoreCase),
+                adminSdHolderSdPerPartition = new Dictionary<string, CommonSecurityDescriptor>(StringComparer.OrdinalIgnoreCase),
+                adminSdHolderProtectedDn = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
                 tier0Sids = new HashSet<SecurityIdentifier>(),
 
                 // Inventory schema classes so we can display pretty names

--- a/engine/Logging.cs
+++ b/engine/Logging.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace adeleg.engine
+{
+    public static class Log
+    {
+        private static TraceSource traceSource;
+
+        public static void Initialize(bool consoleEnabled, string logFilePath)
+        {
+            if (!consoleEnabled && string.IsNullOrEmpty(logFilePath))
+                return;
+
+            traceSource = new TraceSource("adeleg", SourceLevels.Verbose);
+            traceSource.Listeners.Clear();
+
+            if (consoleEnabled)
+            {
+                var consoleListener = new ConsoleTraceListener(true);
+                traceSource.Listeners.Add(consoleListener);
+            }
+
+            if (!string.IsNullOrEmpty(logFilePath))
+            {
+                var fileListener = new TextWriterTraceListener(logFilePath);
+                traceSource.Listeners.Add(fileListener);
+            }
+        }
+
+        public static void Verbose(string message)
+        {
+            if (traceSource == null) return;
+            traceSource.TraceEvent(TraceEventType.Verbose, 0,
+                DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff") + " [VERBOSE] " + message);
+            traceSource.Flush();
+        }
+
+        public static void Info(string message)
+        {
+            if (traceSource == null) return;
+            traceSource.TraceEvent(TraceEventType.Information, 0,
+                DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff") + " [INFO] " + message);
+            traceSource.Flush();
+        }
+
+        public static void Warn(string message)
+        {
+            if (traceSource == null) return;
+            traceSource.TraceEvent(TraceEventType.Warning, 0,
+                DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff") + " [WARN] " + message);
+            traceSource.Flush();
+        }
+
+        public static void Error(string message)
+        {
+            if (traceSource == null) return;
+            traceSource.TraceEvent(TraceEventType.Error, 0,
+                DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff") + " [ERROR] " + message);
+            traceSource.Flush();
+        }
+
+        public static void Close()
+        {
+            if (traceSource == null) return;
+            traceSource.Flush();
+            traceSource.Close();
+            traceSource = null;
+        }
+    }
+}

--- a/engine/Logging.cs
+++ b/engine/Logging.cs
@@ -9,7 +9,7 @@ namespace adeleg.engine
 
         public static void Initialize(bool consoleEnabled, string logFilePath)
         {
-            if (!consoleEnabled && string.IsNullOrEmpty(logFilePath))
+            if (!consoleEnabled && string.IsNullOrWhiteSpace(logFilePath))
             {
                 Close();
                 return;
@@ -26,7 +26,7 @@ namespace adeleg.engine
                 traceSource.Listeners.Add(consoleListener);
             }
 
-            if (!string.IsNullOrEmpty(logFilePath))
+            if (!string.IsNullOrWhiteSpace(logFilePath))
             {
                 var fileListener = new TextWriterTraceListener(logFilePath);
                 traceSource.Listeners.Add(fileListener);

--- a/engine/Logging.cs
+++ b/engine/Logging.cs
@@ -10,7 +10,12 @@ namespace adeleg.engine
         public static void Initialize(bool consoleEnabled, string logFilePath)
         {
             if (!consoleEnabled && string.IsNullOrEmpty(logFilePath))
+            {
+                Close();
                 return;
+            }
+
+            Close();
 
             traceSource = new TraceSource("adeleg", SourceLevels.Verbose);
             traceSource.Listeners.Clear();
@@ -31,33 +36,43 @@ namespace adeleg.engine
         public static void Verbose(string message)
         {
             if (traceSource == null) return;
-            traceSource.TraceEvent(TraceEventType.Verbose, 0,
-                DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff") + " [VERBOSE] " + message);
-            traceSource.Flush();
+            string line = string.Format("{0} [VERBOSE] {1}", DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"), message);
+            foreach (TraceListener listener in traceSource.Listeners)
+            {
+                listener.WriteLine(line);
+            }
         }
 
         public static void Info(string message)
         {
             if (traceSource == null) return;
-            traceSource.TraceEvent(TraceEventType.Information, 0,
-                DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff") + " [INFO] " + message);
-            traceSource.Flush();
+            string line = string.Format("{0} [INFO] {1}", DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"), message);
+            foreach (TraceListener listener in traceSource.Listeners)
+            {
+                listener.WriteLine(line);
+            }
         }
 
         public static void Warn(string message)
         {
             if (traceSource == null) return;
-            traceSource.TraceEvent(TraceEventType.Warning, 0,
-                DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff") + " [WARN] " + message);
-            traceSource.Flush();
+            string line = string.Format("{0} [WARN] {1}", DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"), message);
+            foreach (TraceListener listener in traceSource.Listeners)
+            {
+                listener.WriteLine(line);
+                listener.Flush();
+            }
         }
 
         public static void Error(string message)
         {
             if (traceSource == null) return;
-            traceSource.TraceEvent(TraceEventType.Error, 0,
-                DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff") + " [ERROR] " + message);
-            traceSource.Flush();
+            string line = string.Format("{0} [ERROR] {1}", DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"), message);
+            foreach (TraceListener listener in traceSource.Listeners)
+            {
+                listener.WriteLine(line);
+                listener.Flush();
+            }
         }
 
         public static void Close()

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -135,12 +135,13 @@ namespace adeleg.engine.connector
             }
             else
             {
-                this.rootDomainNC = null;
-                Log.Warn("RootDSE did not return 'rootDomainNamingContext' attribute");
+                throw new Exception("RootDSE did not return 'rootDomainNamingContext' attribute. Ensure the domain controller is reachable and returns valid RootDSE information.");
             }
-            Log.Verbose($"RootDSE rootDomainNamingContext = {this.rootDomainNC ?? "(null)"}");
-            if (this.rootDomainNC == null)
-                Log.Warn("rootDomainNamingContext was not returned by the domain controller's RootDSE");
+            if (string.IsNullOrEmpty(this.rootDomainNC))
+            {
+                throw new Exception("RootDSE returned a null or empty 'rootDomainNamingContext' value. Ensure the domain controller is reachable and returns valid RootDSE information.");
+            }
+            Log.Verbose($"RootDSE rootDomainNamingContext = {this.rootDomainNC}");
 
             if (attrs.Contains("namingContexts"))
             {

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -433,7 +433,9 @@ namespace adeleg.engine.connector
                         var ctx2 = new DirectoryContext(DirectoryContextType.Domain, partner);
                         var dc = DomainController.FindOne(ctx2, LocatorOptions.ForceRediscovery | LocatorOptions.WriteableRequired);
                         Log.Info($"Connecting to trust partner {partner} via DC {dc.IPAddress}");
-                        dataSources.Add(new LdapLiveConnector(dc.IPAddress, 389, dataSource.creds)); // reuse same credentials as the trust party we already have
+                        var newConnector = new LdapLiveConnector(dc.IPAddress, 389, dataSource.creds); // reuse same credentials as the trust party we already have
+                        dataSources.Add(newConnector);
+                        dnsDomainsCovered[partner.ToLower()] = newConnector;
                     }
                 }
             }

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -92,16 +92,64 @@ namespace adeleg.engine.connector
         {
             var res = GetLdapRecords(schemaNC, SearchScope.Base,
                          "(objectClass=*)",
-                         new string[] { "schemaNamingContext", "configurationNamingContext", "rootDomainNamingContext", "namingContexts" }).First();
-            this.schemaNC = (string)res.Attributes["schemaNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+                         new string[] { "schemaNamingContext", "configurationNamingContext", "rootDomainNamingContext", "namingContexts" }).FirstOrDefault();
+
+            if (res == null)
+            {
+                Log.Warn("RootDSE query did not return any entries");
+                this.schemaNC = null;
+                this.configurationNC = null;
+                this.rootDomainNC = null;
+                this.partitionDNs = new string[0];
+                return;
+            }
+
+            var attrs = res.Attributes;
+
+            if (attrs.Contains("schemaNamingContext"))
+            {
+                this.schemaNC = (string)attrs["schemaNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+            }
+            else
+            {
+                this.schemaNC = null;
+                Log.Warn("RootDSE did not return 'schemaNamingContext' attribute");
+            }
             Log.Verbose($"RootDSE schemaNamingContext = {this.schemaNC ?? "(null)"}");
-            this.configurationNC = (string)res.Attributes["configurationNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+
+            if (attrs.Contains("configurationNamingContext"))
+            {
+                this.configurationNC = (string)attrs["configurationNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+            }
+            else
+            {
+                this.configurationNC = null;
+                Log.Warn("RootDSE did not return 'configurationNamingContext' attribute");
+            }
             Log.Verbose($"RootDSE configurationNamingContext = {this.configurationNC ?? "(null)"}");
-            this.rootDomainNC = (string)res.Attributes["rootDomainNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+
+            if (attrs.Contains("rootDomainNamingContext"))
+            {
+                this.rootDomainNC = (string)attrs["rootDomainNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+            }
+            else
+            {
+                this.rootDomainNC = null;
+                Log.Warn("RootDSE did not return 'rootDomainNamingContext' attribute");
+            }
             Log.Verbose($"RootDSE rootDomainNamingContext = {this.rootDomainNC ?? "(null)"}");
             if (this.rootDomainNC == null)
                 Log.Warn("rootDomainNamingContext was not returned by the domain controller's RootDSE");
-            this.partitionDNs = (string[])res.Attributes["namingContexts"].GetValues(typeof(string));
+
+            if (attrs.Contains("namingContexts"))
+            {
+                this.partitionDNs = (string[])attrs["namingContexts"].GetValues(typeof(string));
+            }
+            else
+            {
+                this.partitionDNs = new string[0];
+                Log.Warn("RootDSE did not return 'namingContexts' attribute");
+            }
             for (int i = 0; i < this.partitionDNs.Length; i++)
                 Log.Verbose($"RootDSE namingContext[{i}] = {this.partitionDNs[i]}");
         }

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -96,12 +96,7 @@ namespace adeleg.engine.connector
 
             if (res == null)
             {
-                Log.Warn("RootDSE query did not return any entries");
-                this.schemaNC = null;
-                this.configurationNC = null;
-                this.rootDomainNC = null;
-                this.partitionDNs = new string[0];
-                return;
+                throw new Exception("RootDSE query did not return any entries. Ensure the domain controller is reachable and returns valid RootDSE information.");
             }
 
             var attrs = res.Attributes;
@@ -112,8 +107,7 @@ namespace adeleg.engine.connector
             }
             else
             {
-                this.schemaNC = null;
-                Log.Warn("RootDSE did not return 'schemaNamingContext' attribute");
+                throw new Exception("RootDSE did not return 'schemaNamingContext' attribute. Ensure the domain controller is reachable and returns valid RootDSE information.");
             }
             Log.Verbose($"RootDSE schemaNamingContext = {this.schemaNC ?? "(null)"}");
 
@@ -123,8 +117,7 @@ namespace adeleg.engine.connector
             }
             else
             {
-                this.configurationNC = null;
-                Log.Warn("RootDSE did not return 'configurationNamingContext' attribute");
+                throw new Exception("RootDSE did not return 'configurationNamingContext' attribute. Ensure the domain controller is reachable and returns valid RootDSE information.");
             }
             Log.Verbose($"RootDSE configurationNamingContext = {this.configurationNC ?? "(null)"}");
 
@@ -147,8 +140,7 @@ namespace adeleg.engine.connector
             }
             else
             {
-                this.partitionDNs = new string[0];
-                Log.Warn("RootDSE did not return 'namingContexts' attribute");
+                throw new Exception("RootDSE did not return 'namingContexts' attribute. Ensure the domain controller is reachable and returns valid RootDSE information.");
             }
             for (int i = 0; i < this.partitionDNs.Length; i++)
                 Log.Verbose($"RootDSE namingContext[{i}] = {this.partitionDNs[i]}");

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -400,12 +400,12 @@ namespace adeleg.engine.connector
         internal static void CrawlDomainsAcrossTrusts(List<IConnector> dataSources, bool includeDomainsOutsideForest)
         {
             // Enumerate all DNS domains we already have
-            Dictionary<string, LdapLiveConnector> dnsDomainsCovered = new Dictionary<string, LdapLiveConnector>();
+            Dictionary<string, LdapLiveConnector> dnsDomainsCovered = new Dictionary<string, LdapLiveConnector>(StringComparer.OrdinalIgnoreCase);
             foreach (LdapLiveConnector conn in dataSources.Cast<LdapLiveConnector>())
             {
                 foreach (string partitionDN in conn.GetPartitionDNs())
                 {
-                    string dnsName = partitionDN.Replace(",", ".").Replace("DC=", "").ToLower();
+                    string dnsName = partitionDN.Replace(",", ".").Replace("DC=", "");
                     dnsDomainsCovered[dnsName] = conn;
                 }
             }
@@ -440,7 +440,7 @@ namespace adeleg.engine.connector
                             Log.Verbose($"Skipping trust partner {partner} (external/forest trust, not crawling outside forest)");
                             continue;
                         }
-                        if (dnsDomainsCovered.ContainsKey(partner.ToLower()))
+                        if (dnsDomainsCovered.ContainsKey(partner))
                         {
                             Log.Verbose($"Skipping trust partner {partner} (already covered)");
                             continue;
@@ -450,7 +450,7 @@ namespace adeleg.engine.connector
                         Log.Info($"Connecting to trust partner {partner} via DC {dc.IPAddress}");
                         var newConnector = new LdapLiveConnector(dc.IPAddress, 389, dataSource.creds); // reuse same credentials as the trust party we already have
                         dataSources.Add(newConnector);
-                        dnsDomainsCovered[partner.ToLower()] = newConnector;
+                        dnsDomainsCovered[partner] = newConnector;
                     }
                 }
             }

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -21,8 +21,8 @@ namespace adeleg.engine.connector
         public string configurationNC = null;
         public string rootDomainNC = null;
         public string[] partitionDNs = new string[0];
-        public Dictionary<string, SecurityIdentifier> domainSidPerPartitionDn = new Dictionary<string, SecurityIdentifier>();
-        public Dictionary<string, CommonSecurityDescriptor> adminSDHolderPerPartitionDn = new Dictionary<string, CommonSecurityDescriptor>();
+        public Dictionary<string, SecurityIdentifier> domainSidPerPartitionDn = new Dictionary<string, SecurityIdentifier>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, CommonSecurityDescriptor> adminSDHolderPerPartitionDn = new Dictionary<string, CommonSecurityDescriptor>(StringComparer.OrdinalIgnoreCase);
 
         public LdapLiveConnector(string server, ushort port, NetworkCredential creds = null)
         {

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -109,7 +109,11 @@ namespace adeleg.engine.connector
             {
                 throw new Exception("RootDSE did not return 'schemaNamingContext' attribute. Ensure the domain controller is reachable and returns valid RootDSE information.");
             }
-            Log.Verbose($"RootDSE schemaNamingContext = {this.schemaNC ?? "(null)"}");
+            if (string.IsNullOrEmpty(this.schemaNC))
+            {
+                throw new Exception("RootDSE returned a null or empty 'schemaNamingContext' value. Ensure the domain controller is reachable and returns valid RootDSE information.");
+            }
+            Log.Verbose($"RootDSE schemaNamingContext = {this.schemaNC}");
 
             if (attrs.Contains("configurationNamingContext"))
             {
@@ -119,7 +123,11 @@ namespace adeleg.engine.connector
             {
                 throw new Exception("RootDSE did not return 'configurationNamingContext' attribute. Ensure the domain controller is reachable and returns valid RootDSE information.");
             }
-            Log.Verbose($"RootDSE configurationNamingContext = {this.configurationNC ?? "(null)"}");
+            if (string.IsNullOrEmpty(this.configurationNC))
+            {
+                throw new Exception("RootDSE returned a null or empty 'configurationNamingContext' value. Ensure the domain controller is reachable and returns valid RootDSE information.");
+            }
+            Log.Verbose($"RootDSE configurationNamingContext = {this.configurationNC}");
 
             if (attrs.Contains("rootDomainNamingContext"))
             {
@@ -137,10 +145,15 @@ namespace adeleg.engine.connector
             if (attrs.Contains("namingContexts"))
             {
                 this.partitionDNs = (string[])attrs["namingContexts"].GetValues(typeof(string));
+                this.partitionDNs = this.partitionDNs.Where(dn => !string.IsNullOrEmpty(dn)).ToArray();
             }
             else
             {
                 throw new Exception("RootDSE did not return 'namingContexts' attribute. Ensure the domain controller is reachable and returns valid RootDSE information.");
+            }
+            if (this.partitionDNs.Length == 0)
+            {
+                throw new Exception("RootDSE returned no valid 'namingContexts' entries. Ensure the domain controller is reachable and returns valid RootDSE information.");
             }
             for (int i = 0; i < this.partitionDNs.Length; i++)
                 Log.Verbose($"RootDSE namingContext[{i}] = {this.partitionDNs[i]}");
@@ -404,6 +417,16 @@ namespace adeleg.engine.connector
                 LdapLiveConnector dataSource = (LdapLiveConnector)dataSources[idx];
                 foreach (string partitionDN in dataSource.GetPartitionDNs())
                 {
+                    // Skip non-domain partitions (schema, config, DNS app partitions) since
+                    // trust objects only exist under CN=System in domain partitions.
+                    if (partitionDN.Equals(dataSource.GetSchemaNC(), StringComparison.OrdinalIgnoreCase) ||
+                        partitionDN.Equals(dataSource.GetConfigurationNC(), StringComparison.OrdinalIgnoreCase) ||
+                        partitionDN.StartsWith("DC=DomainDnsZones,", StringComparison.OrdinalIgnoreCase) ||
+                        partitionDN.StartsWith("DC=ForestDnsZones,", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Log.Verbose($"Skipping non-domain partition {partitionDN} for trust enumeration");
+                        continue;
+                    }
                     var trusts = dataSource.GetLdapRecords("CN=System," + partitionDN, SearchScope.Subtree, "(trustPartner=*)", new string[] { "trustPartner", "trustType" });
                     foreach (SearchResultEntry trust in trusts)
                     {

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -29,6 +29,7 @@ namespace adeleg.engine.connector
             this.creds = creds;
 
             var srv = new LdapDirectoryIdentifier(server, port, false, false);
+            Log.Info($"Connecting to LDAP server {server}:{port}");
             if (creds == null)
             {
                 this.connection = new LdapConnection(srv);
@@ -42,6 +43,8 @@ namespace adeleg.engine.connector
             this.connection.SessionOptions.Signing = true;
 
             this.connection.Bind();
+            Log.Info($"LDAP Bind() successful to {server}:{port}");
+            Log.Verbose(creds == null ? "Using Windows integrated authentication" : $"Using explicit credentials for {creds.Domain}\\{creds.UserName}");
 
             this.PrefetchRootDseInformation();
             this.PrefetchDomainSIDs();
@@ -90,9 +93,16 @@ namespace adeleg.engine.connector
                          "(objectClass=*)",
                          new string[] { "schemaNamingContext", "configurationNamingContext", "rootDomainNamingContext", "namingContexts" }).First();
             this.schemaNC = (string)res.Attributes["schemaNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+            Log.Verbose($"RootDSE schemaNamingContext = {this.schemaNC ?? "(null)"}");
             this.configurationNC = (string)res.Attributes["configurationNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+            Log.Verbose($"RootDSE configurationNamingContext = {this.configurationNC ?? "(null)"}");
             this.rootDomainNC = (string)res.Attributes["rootDomainNamingContext"].GetValues(typeof(string)).FirstOrDefault();
+            Log.Verbose($"RootDSE rootDomainNamingContext = {this.rootDomainNC ?? "(null)"}");
+            if (this.rootDomainNC == null)
+                Log.Warn("rootDomainNamingContext was not returned by the domain controller's RootDSE");
             this.partitionDNs = (string[])res.Attributes["namingContexts"].GetValues(typeof(string));
+            for (int i = 0; i < this.partitionDNs.Length; i++)
+                Log.Verbose($"RootDSE namingContext[{i}] = {this.partitionDNs[i]}");
         }
 
         private void PrefetchDomainSIDs()
@@ -105,6 +115,11 @@ namespace adeleg.engine.connector
                     byte[] sidBytes = (byte[])res.First().Attributes["objectSid"].GetValues(typeof(byte[]))[0];
                     SecurityIdentifier sid = new SecurityIdentifier(sidBytes, 0);
                     this.domainSidPerPartitionDn.Add(partitionDN, sid);
+                    Log.Verbose($"Partition {partitionDN} has domain SID {sid}");
+                }
+                else
+                {
+                    Log.Verbose($"Partition {partitionDN} has no objectSid (not a domain partition)");
                 }
             }
         }
@@ -117,6 +132,7 @@ namespace adeleg.engine.connector
                 byte[] bytes = (byte[])res.Attributes["ntSecurityDescriptor"].GetValues(typeof(byte[]))[0];
                 CommonSecurityDescriptor sd = new CommonSecurityDescriptor(true, true, bytes, 0);
                 this.adminSDHolderPerPartitionDn.Add(partitionDN, sd);
+                Log.Verbose($"Retrieved AdminSDHolder security descriptor for {partitionDN}");
             }
         }
 
@@ -283,10 +299,12 @@ namespace adeleg.engine.connector
             {
                 var ctx = new DirectoryContext(DirectoryContextType.Domain);
                 var dc = DomainController.FindOne(ctx, LocatorOptions.ForceRediscovery | LocatorOptions.WriteableRequired);
+                Log.Info($"Auto-located domain controller: {dc.Name}");
                 return dc.Name;
             }
             catch (Exception)
             {
+                Log.Warn("Failed to auto-locate a domain controller via DC Locator");
                 return null;
             }
         }
@@ -349,16 +367,20 @@ namespace adeleg.engine.connector
                         string partner = (string)trust.Attributes["trustPartner"].GetValues(typeof(string)).FirstOrDefault();
                         TrustType type = (TrustType)Enum.Parse(typeof(TrustType), (string)trust.Attributes["trustType"].GetValues(typeof(string)).FirstOrDefault());
 
+                        Log.Info($"Discovered trust partner: {partner} (type: {type})");
+
                         if (includeDomainsOutsideForest && (type == TrustType.External || type == TrustType.Forest || type == TrustType.Kerberos))
                         {
                             continue;
                         }
                         if (dnsDomainsCovered.ContainsKey(partner.ToLower()))
                         {
+                            Log.Verbose($"Skipping trust partner {partner} (already covered)");
                             continue;
                         }
                         var ctx2 = new DirectoryContext(DirectoryContextType.Domain, partner);
                         var dc = DomainController.FindOne(ctx2, LocatorOptions.ForceRediscovery | LocatorOptions.WriteableRequired);
+                        Log.Info($"Connecting to trust partner {partner} via DC {dc.IPAddress}");
                         dataSources.Add(new LdapLiveConnector(dc.IPAddress, 389, dataSource.creds)); // reuse same credentials as the trust party we already have
                     }
                 }

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -405,12 +405,14 @@ namespace adeleg.engine.connector
                 }
             }
 
-            // Now, for each domain partition, enumerate trusts and crawl domains not already covered
-            foreach (LdapLiveConnector dataSource in dataSources.Cast<LdapLiveConnector>())
+            // Now, for each domain partition, enumerate trusts and crawl domains not already covered.
+            // Use a for loop with index because new connectors may be added during iteration.
+            for (int idx = 0; idx < dataSources.Count; idx++)
             {
+                LdapLiveConnector dataSource = (LdapLiveConnector)dataSources[idx];
                 foreach (string partitionDN in dataSource.GetPartitionDNs())
                 {
-                    var trusts = dataSource.GetLdapRecords("CN=System" + partitionDN, SearchScope.Subtree, "(trustPartner=*)", new string[] { "trustPartner", "trustType" });
+                    var trusts = dataSource.GetLdapRecords("CN=System," + partitionDN, SearchScope.Subtree, "(trustPartner=*)", new string[] { "trustPartner", "trustType" });
                     foreach (SearchResultEntry trust in trusts)
                     {
                         string partner = (string)trust.Attributes["trustPartner"].GetValues(typeof(string)).FirstOrDefault();

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -45,7 +45,7 @@ namespace adeleg.engine.connector
 
             this.connection.Bind();
             Log.Info($"LDAP Bind() successful to {server}:{port}");
-            Log.Verbose(creds == null ? "Using Windows integrated authentication" : $"Using explicit credentials for {creds.Domain}\\{creds.UserName}");
+            Log.Verbose(creds == null ? "Using Windows integrated authentication" : "Using explicit credentials");
 
             this.PrefetchRootDseInformation();
             this.PrefetchDomainSIDs();

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text.RegularExpressions;
+using adeleg.engine;
 
 namespace adeleg.engine.connector
 {
@@ -369,8 +370,9 @@ namespace adeleg.engine.connector
 
                         Log.Info($"Discovered trust partner: {partner} (type: {type})");
 
-                        if (includeDomainsOutsideForest && (type == TrustType.External || type == TrustType.Forest || type == TrustType.Kerberos))
+                        if (!includeDomainsOutsideForest && (type == TrustType.External || type == TrustType.Forest || type == TrustType.Kerberos))
                         {
+                            Log.Verbose($"Skipping trust partner {partner} (external/forest trust, not crawling outside forest)");
                             continue;
                         }
                         if (dnsDomainsCovered.ContainsKey(partner.ToLower()))

--- a/engine/connector/LdapLiveConnector.cs
+++ b/engine/connector/LdapLiveConnector.cs
@@ -109,10 +109,10 @@ namespace adeleg.engine.connector
         {
             foreach (string partitionDN in this.partitionDNs)
             {
-                var res = GetLdapRecords(partitionDN, SearchScope.Base, "(objectSid=*)", new string[] { "objectSid" });
-                if (res.Count() > 0)
+                SearchResultEntry entry = GetLdapRecords(partitionDN, SearchScope.Base, "(objectSid=*)", new string[] { "objectSid" }).FirstOrDefault();
+                if (entry != null)
                 {
-                    byte[] sidBytes = (byte[])res.First().Attributes["objectSid"].GetValues(typeof(byte[]))[0];
+                    byte[] sidBytes = (byte[])entry.Attributes["objectSid"].GetValues(typeof(byte[]))[0];
                     SecurityIdentifier sid = new SecurityIdentifier(sidBytes, 0);
                     this.domainSidPerPartitionDn.Add(partitionDN, sid);
                     Log.Verbose($"Partition {partitionDN} has domain SID {sid}");

--- a/gui/DataSourceDialog.cs
+++ b/gui/DataSourceDialog.cs
@@ -41,7 +41,7 @@ namespace adeleg.gui
             {
                 var ctx = new DirectoryContext(DirectoryContextType.Domain);
                 var dc = DomainController.FindOne(ctx, LocatorOptions.ForceRediscovery | LocatorOptions.WriteableRequired);
-                Log.Info($"Computer is AD-joined, can use DC : {dc}");
+                Console.WriteLine($" [+] Computer is AD-joined, can use DC : {dc}");
                 this.currentDomainViaDcLocator.Checked = true;
                 this.implicitCredentials.Checked = true;
                 this.currentDomainViaDcLocator.Checked = true;
@@ -50,7 +50,7 @@ namespace adeleg.gui
                 this.ActiveControl = this.connectButton;
             }
             catch (Exception) {
-                Log.Info("Computer is not AD-joined or could not locate a domain controller, please input server path and credentials");
+                Console.WriteLine(" [.] Computer is not AD-joined or could not locate a domain controller, please input server path and credentials");
                 this.useExplicitCredentials.Checked = true;
                 this.useExplicitDomainList.Checked = true;
                 this.currentDomainViaDcLocator.Enabled = false;

--- a/gui/DataSourceDialog.cs
+++ b/gui/DataSourceDialog.cs
@@ -41,7 +41,7 @@ namespace adeleg.gui
             {
                 var ctx = new DirectoryContext(DirectoryContextType.Domain);
                 var dc = DomainController.FindOne(ctx, LocatorOptions.ForceRediscovery | LocatorOptions.WriteableRequired);
-                Console.WriteLine($" [+] Computer is AD-joined, can use DC : {dc}");
+                Log.Info($"Computer is AD-joined, can use DC : {dc}");
                 this.currentDomainViaDcLocator.Checked = true;
                 this.implicitCredentials.Checked = true;
                 this.currentDomainViaDcLocator.Checked = true;
@@ -50,7 +50,7 @@ namespace adeleg.gui
                 this.ActiveControl = this.connectButton;
             }
             catch (Exception) {
-                Console.WriteLine(" [.] Computer is not AD-joined or could not locate a domain controller, please input server path and credentials");
+                Log.Info("Computer is not AD-joined or could not locate a domain controller, please input server path and credentials");
                 this.useExplicitCredentials.Checked = true;
                 this.useExplicitDomainList.Checked = true;
                 this.currentDomainViaDcLocator.Enabled = false;


### PR DESCRIPTION
In response to https://github.com/mtth-bfft/adeleg/issues/44, I thought it would be good to add logging/instrumentation to adeleg so that we can get a better idea of what's happening that causes the "Unable to find root domain naming context on this domain controller" error.

Issues https://github.com/mtth-bfft/adeleg/issues/49 and https://github.com/mtth-bfft/adeleg/issues/50 are addressed in this PR and can be closed if this PR is accepted.

With that being said, I didn't realize that the current release version (1.2) is several years old, and written in Rust - whereas the code in this repository is written in C# (i.e., I didn't realize that the rewrite wasn't occurring in a branch). With that being said, this PR will be useful for troubleshooting -- assuming the "Unable to find root domain naming context on this domain controller" or similar issues persist in the C# rewrite -- but the code change will not fix people's immediate issues with version 1.2 of adeleg.